### PR TITLE
fix: Migrate from istanbul to nyc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ coverage
 # Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
 .grunt
 
+# Build
+.nyc_output/*
+
 # Compiled binary addons (http://nodejs.org/api/addons.html)
 build/Release
 

--- a/package.json
+++ b/package.json
@@ -12,13 +12,13 @@
   ],
   "dependencies": {
     "foreground-child": "^2.0.0",
-    "istanbul": "^0.4.5",
+    "nyc": "^15.0.0",
     "testit": "^3.0.0"
   },
   "scripts": {
     "test": "node test",
     "posttest": "xo --space=2 index.js",
-    "coverage": "istanbul cover test"
+    "coverage": "nyc node test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Per https://www.npmjs.com/package/istanbul  the package has been deprecated.

> This module is no longer maintained, try this instead: npm i nyc Visit https://istanbul.js.org/integrations for other alternatives.

This change will also fix the following warnings when running `npm install`

> ![image](https://user-images.githubusercontent.com/6448697/72435598-48b73180-3753-11ea-83ba-6ccf4301607c.png)
> npm WARN deprecated istanbul@0.4.5: This module is no longer maintained, try this instead:
> npm WARN deprecated   npm i nyc
> npm WARN deprecated Visit https://istanbul.js.org/integrations for other alternatives.

