### PR TITLE
feat: async test case switch

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,11 +71,12 @@ function addTests(transform, testDirectory, test) {
     });
     const expected = read(join(directory, 'expected.*'));
 
-    function checkFunctionOutput(template) {
+    async function checkFunctionOutput(template) {
       if ((dependencies && dependencies.length > 0) || (typeof template === 'object' && template)) {
         assert(typeof template === 'object' && template, ' template should be an object because this module tracks dependencies');
         assert(typeof template.fn === 'function', 'template.fn should be a function');
-        assertEqual(template.fn(locals).trim(), expected);
+        let result = await Promise.resolve(template.fn(locals)).then(rendered => rendered.trim())
+        assertEqual(result, expected);
         assert(Array.isArray(template.dependencies), ' template.dependencies should be an array');
         assert(template.dependencies.every(path => {
           return typeof path === 'string';
@@ -85,7 +86,8 @@ function addTests(transform, testDirectory, test) {
         }), dependencies || []);
       } else {
         assert(typeof template === 'function', 'template should be a function, or an object with an "fn" property of type function and a "dependencies" property that is an array.');
-        assertEqual(template(locals).trim(), expected);
+        let result = await Promise.resolve(template(locals)).then(rendered => rendered.trim()) 
+        assertEqual(result, expected);
       }
     }
 
@@ -104,7 +106,7 @@ function addTests(transform, testDirectory, test) {
       }
     }
 
-    if (transform.compile) {
+    if (transform.compile && directory.indexOf("_async") === -1) {
       test(transform.name + '.compile()', () => {
         const template = transform.compile(input, options);
         checkFunctionOutput(template);
@@ -119,7 +121,7 @@ function addTests(transform, testDirectory, test) {
       });
     }
 
-    if (transform.compileFile) {
+    if (transform.compileFile && directory.indexOf("_async") === -1) {
       test(transform.name + '.compileFile()', () => {
         const template = transform.compileFile(inputFile, options);
         checkFunctionOutput(template);
@@ -134,7 +136,7 @@ function addTests(transform, testDirectory, test) {
       });
     }
 
-    if (transform.render) {
+    if (transform.render && directory.indexOf("_async") === -1) {
       test(transform.name + '.render()', () => {
         const output = transform.render(input, options, locals);
         checkOutput(output);
@@ -149,7 +151,7 @@ function addTests(transform, testDirectory, test) {
       });
     }
 
-    if (transform.renderFile) {
+    if (transform.renderFile && directory.indexOf("_async") === -1) {
       test(transform.name + '.renderFile()', () => {
         const output = transform.renderFile(inputFile, options, locals);
         checkOutput(output);

--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ function addTests(transform, testDirectory, test) {
       if ((dependencies && dependencies.length > 0) || (typeof template === 'object' && template)) {
         assert(typeof template === 'object' && template, ' template should be an object because this module tracks dependencies');
         assert(typeof template.fn === 'function', 'template.fn should be a function');
-        let result = await Promise.resolve(template.fn(locals)).then(rendered => rendered.trim())
+        const result = await Promise.resolve(template.fn(locals)).then(rendered => rendered.trim());
         assertEqual(result, expected);
         assert(Array.isArray(template.dependencies), ' template.dependencies should be an array');
         assert(template.dependencies.every(path => {
@@ -86,7 +86,7 @@ function addTests(transform, testDirectory, test) {
         }), dependencies || []);
       } else {
         assert(typeof template === 'function', 'template should be a function, or an object with an "fn" property of type function and a "dependencies" property that is an array.');
-        let result = await Promise.resolve(template(locals)).then(rendered => rendered.trim()) 
+        const result = await Promise.resolve(template(locals)).then(rendered => rendered.trim());
         assertEqual(result, expected);
       }
     }
@@ -106,7 +106,7 @@ function addTests(transform, testDirectory, test) {
       }
     }
 
-    if (transform.compile && directory.indexOf("_async") === -1) {
+    if (transform.compile && !directory.includes('_async')) {
       test(transform.name + '.compile()', () => {
         const template = transform.compile(input, options);
         checkFunctionOutput(template);
@@ -121,7 +121,7 @@ function addTests(transform, testDirectory, test) {
       });
     }
 
-    if (transform.compileFile && directory.indexOf("_async") === -1) {
+    if (transform.compileFile && !directory.includes('_async')) {
       test(transform.name + '.compileFile()', () => {
         const template = transform.compileFile(inputFile, options);
         checkFunctionOutput(template);
@@ -136,7 +136,7 @@ function addTests(transform, testDirectory, test) {
       });
     }
 
-    if (transform.render && directory.indexOf("_async") === -1) {
+    if (transform.render && !directory.includes('_async')) {
       test(transform.name + '.render()', () => {
         const output = transform.render(input, options, locals);
         checkOutput(output);
@@ -151,7 +151,7 @@ function addTests(transform, testDirectory, test) {
       });
     }
 
-    if (transform.renderFile && directory.indexOf("_async") === -1) {
+    if (transform.renderFile && !directory.includes('_async')) {
       test(transform.name + '.renderFile()', () => {
         const output = transform.renderFile(inputFile, options, locals);
         checkOutput(output);


### PR DESCRIPTION
Fixes #38 

Test-jstransformer applies all tests to each method it can find,
regardless of the method being asynchronous or not. This is a problem
for tests that require a method to be asynchronous as mentioned in issue #38 . 
These test cases should only be applied to the asynchronous methods. This 
commit checks for the text '_async' in the folder name. If it can find it, only the
asynchronous test cases are performed. Asynchronous methods are tested
on synchronous test cases, because that way around it should work,
regardless of a method being asynchronous.

`checkFunctionOutput` is now asynchronous. This is done, because it is
not a given that `template.fn(locals)` returns a string. Hence this test
case can fail because `template.fn(locals).trim()` returns an error. By
wrapping it in a `Promise.resolve()` both the situations where
`template.fn(locals)` returns a string or a Promise are covered. This
is also how the jstranformer library works, so the tests now better
mimmick the behavior of the actual library.